### PR TITLE
ANSI коды для полужирного и курсива

### DIFF
--- a/tiny.lua
+++ b/tiny.lua
@@ -16,12 +16,12 @@ if API == 'stead3' then
 	std.savepath = instead.savepath
 	function iface:em(str)
 		if type(str) == 'string' then
-			return '/'..str..'/'
+			return "\27[2m"..str.."\27[0m"
 		end
 	end
 	function iface:bold(str)
 		if type(str) == 'string' then
-			return '*'..str..'*'
+			return "\27[1m"..str.."\27[0m"
 		end
 	end
 	instead.get_picture = function()


### PR DESCRIPTION
В терминале есть очень даже стандарт полужирного выделения: ANSI-коды. Поэтому этот коммит применяет их к полужирному тексту. Это же будет полезно для незрячих игроков.

Для курсива нет единого стандарта, поэтому, чтобы не вводить проблем совместимости, я выбрал ANSI код 2 вместо 3 (блёклый текст), он шире поддерживается.